### PR TITLE
Fix spending trend division by zero

### DIFF
--- a/lib/services/transaction_service.dart
+++ b/lib/services/transaction_service.dart
@@ -169,8 +169,13 @@ class TransactionService extends ChangeNotifier {
     if (monthly.length < 2) return 'Dados insuficientes';
 
     List<String> sortedMonths = monthly.keys.toList()..sort();
-    double lastMonth = monthly[sortedMonths[sortedMonths.length - 1]] ?? 0;
+    double lastMonth = monthly[sortedMonths.last] ?? 0;
     double previousMonth = monthly[sortedMonths[sortedMonths.length - 2]] ?? 0;
+
+    if (previousMonth == 0) {
+      // Evita divisao por zero quando nao ha gastos no mes anterior
+      return lastMonth == 0 ? 'Manteve estável' : 'Dados insuficientes';
+    }
 
     if (lastMonth > previousMonth) {
       double increase = ((lastMonth - previousMonth) / previousMonth * 100);


### PR DESCRIPTION
## Summary
- avoid division by zero in `getSpendingTrend`

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7d0208188321aa18f73605122663