### PR TITLE
Update dependencies for Flutter 3.32

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,23 +13,23 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  fl_chart: ^0.65.0
+  fl_chart: ^1.0.0
   shared_preferences: ^2.2.2
   provider: ^6.1.1
 
   # Firebase Dependencies (latest stable versions)
-  firebase_core: ^2.24.2
-  firebase_auth: ^4.15.3
-  cloud_firestore: ^4.13.6
+  firebase_core: ^3.14.0
+  firebase_auth: ^5.6.0
+  cloud_firestore: ^5.6.9
 
   # Authentication
-  google_sign_in: ^6.1.6
+  google_sign_in: ^7.0.0
   crypto: ^3.0.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- update Firebase plugins and fl_chart to latest major versions
- update google_sign_in and flutter_lints

## Testing
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8149d7548321a1f4c638bf7742d6