### PR TITLE
Fix google sign-in dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   cloud_firestore: ^5.6.9
 
   # Authentication
-  google_sign_in: ^7.0.0
+  google_sign_in: ^6.3.0
   crypto: ^3.0.3
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- fix google_sign_in version to ^6.3.0

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a82c6d5b483219d4d137e55f8cdef