### PR TITLE
Fix fl_chart tooltip parameter

### DIFF
--- a/lib/widgets/line_chart.dart
+++ b/lib/widgets/line_chart.dart
@@ -34,6 +34,11 @@ class LineChartWidget extends StatelessWidget {
           height: 200,
           child: LineChart(
             LineChartData(
+              lineTouchData: LineTouchData(
+                touchTooltipData: LineTouchTooltipData(
+                  tooltipBackgroundColor: Colors.black87,
+                ),
+              ),
               lineBarsData: [
                 LineChartBarData(
                   color: AppColors.expense,


### PR DESCRIPTION
## Summary
- use `tooltipBackgroundColor` in `LineChartWidget`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a836ccc9c83219c7247d86ca1ecb2