### PR TITLE
Fix fl_chart tooltip parameter

### DIFF
--- a/lib/widgets/line_chart.dart
+++ b/lib/widgets/line_chart.dart
@@ -36,7 +36,7 @@ class LineChartWidget extends StatelessWidget {
             LineChartData(
               lineTouchData: LineTouchData(
                 touchTooltipData: LineTouchTooltipData(
-                  tooltipBackgroundColor: Colors.black87,
+                  tooltipBgColor: Colors.black87,
                 ),
               ),
               lineBarsData: [


### PR DESCRIPTION
## Summary
- adjust `LineTouchTooltipData` parameter for current fl_chart API

## Testing
- `flutter build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a845ffd688321b43c0cad400b62e5